### PR TITLE
Faster eigensolver for the benchmark

### DIFF
--- a/src/dirac.f90
+++ b/src/dirac.f90
@@ -234,7 +234,7 @@ contains
     real(dp) :: E_dirac_shift
     integer :: idx
     logical :: accurate_eigensolver
-    accurate_eigensolver = .true.
+    accurate_eigensolver = .false.
     iter = iter + 1
     print *, "SCF iteration:", iter
     Vin = reshape(x, shape(Vin))

--- a/src/lapack.f90
+++ b/src/lapack.f90
@@ -77,6 +77,18 @@ interface
     REAL(dp)           A( LDA, * ), B( LDB, * ), W( * ), WORK( * )
     END SUBROUTINE
 
+    SUBROUTINE DSYGVX( ITYPE, JOBZ, RANGE, UPLO, N, A, LDA, B, LDB, &
+                       VL, VU, IL, IU, ABSTOL, M, W, Z, LDZ, WORK, &
+                       LWORK, IWORK, IFAIL, INFO )
+    import :: dp
+    CHARACTER          JOBZ, RANGE, UPLO
+    INTEGER            IL, INFO, ITYPE, IU, LDA, LDB, LDZ, LWORK, M, N
+    REAL(dp)           ABSTOL, VL, VU
+    INTEGER            IFAIL( * ), IWORK( * )
+    REAL(dp)           A( LDA, * ), B( LDB, * ), W( * ), WORK( * ), &
+                       Z( LDZ, * )
+    END SUBROUTINE
+
     REAL(dp) FUNCTION DLAMCH( CMACH )
     import :: dp
     CHARACTER          CMACH

--- a/src/linalg.f90
+++ b/src/linalg.f90
@@ -25,7 +25,7 @@ contains
     ! lapack variables
     integer :: lwork, liwork, info
     integer, allocatable :: iwork(:), ifail(:)
-    real(dp), allocatable :: Bmt(:,:), work(:), Z(:,:)
+    real(dp), allocatable :: Bmt(:,:), work(:), Z(:,:), Amt(:,:)
     integer :: il, iu, M
     real(dp) :: abstol
 
@@ -37,19 +37,18 @@ contains
     lwork = 1 + 6*n + 2*n**2
     liwork = 3 + 5*n
     allocate(Bmt(n,n), work(lwork), iwork(liwork))
+    allocate(Amt(n,n))
     allocate(ifail(n))
-    c = Am; Bmt = Bm  ! Bmt temporaries overwritten by dsygvd
+    Amt = Am; Bmt = Bm  ! Bmt temporaries overwritten by dsygvd
     !call dsygvd(1,'V','L',n,c,n,Bmt,n,lam,work,lwork,iwork,liwork,info)
     il = 1
     iu = 7
     M = iu-il+1
     allocate(z(n,M))
-    abstol = 1e-8_dp
-    call dsygvx(1,'V','I','L',n,c,n,Bmt,n, &
-        0._dp, 0._dp, 1, 7, abstol, M, lam, z, n, work, &
+    abstol = 1e-4_dp
+    call dsygvx(1,'V','I','L',n,Amt,n,Bmt,n, &
+        0._dp, 0._dp, 1, 7, abstol, M, lam, c, n, work, &
         lwork, iwork, ifail, info)
-    c = 0
-    c(:,:M) = z
     !SUBROUTINE DSYGVD( ITYPE, JOBZ, UPLO, N, A, LDA, B, LDB, W, WORK, &
     !                   LWORK, IWORK, LIWORK, INFO )
     !SUBROUTINE DSYGVX( ITYPE, JOBZ, RANGE, UPLO, N, A, LDA, B, LDB, &

--- a/src/linalg.f90
+++ b/src/linalg.f90
@@ -36,17 +36,15 @@ contains
     call assert_shape(c, [n, n], "eigh", "c")
     lwork = 1 + 6*n + 2*n**2
     liwork = 3 + 5*n
-    allocate(Bmt(n,n), work(lwork), iwork(liwork))
-    allocate(Amt(n,n))
+    allocate(work(lwork), iwork(liwork))
     allocate(ifail(n))
-    Amt = Am; Bmt = Bm  ! Bmt temporaries overwritten by dsygvd
     !call dsygvd(1,'V','L',n,c,n,Bmt,n,lam,work,lwork,iwork,liwork,info)
     il = 1
     iu = 7
     M = iu-il+1
     allocate(z(n,M))
     abstol = 1e-4_dp
-    call dsygvx(1,'V','I','L',n,Amt,n,Bmt,n, &
+    call dsygvx(1,'V','I','L',n,Am,n,Bm,n, &
         0._dp, 0._dp, 1, 7, abstol, M, lam, c, n, work, &
         lwork, iwork, ifail, info)
     !SUBROUTINE DSYGVD( ITYPE, JOBZ, UPLO, N, A, LDA, B, LDB, W, WORK, &


### PR DESCRIPTION
TODO:
* [ ] Expose this cleanly, similarly to the Schroedinger expert lapack interface
* [ ] change (lower) the number of requested eigenvectors based on kappa