### PR TITLE
Fastest DFT Dirac

### DIFF
--- a/src/dirac.f90
+++ b/src/dirac.f90
@@ -234,7 +234,7 @@ contains
     real(dp) :: E_dirac_shift
     integer :: idx
     logical :: accurate_eigensolver
-    accurate_eigensolver = .true.
+    accurate_eigensolver = .false.
     iter = iter + 1
     print *, "SCF iteration:", iter
     Vin = reshape(x, shape(Vin))

--- a/src/dirac.f90
+++ b/src/dirac.f90
@@ -37,7 +37,7 @@ real(dp), intent(inout) :: D(:,:), S(:,:), H(:,:), lam(:), lam_tmp(:), eng(:)
 real(dp), intent(out) :: V(:,:)
 integer, intent(out) :: idx
 real(dp), intent(in) :: E_dirac_shift
-integer :: kappa, i
+integer :: kappa, i, nlam
 idx = 0
 do kappa = Lmin, Lmax
     if (kappa == 0) cycle
@@ -61,13 +61,15 @@ do kappa = Lmin, Lmax
 
     if (accurate_eigensolver) then
         call eigh(H, S, lam)
-        call eigh(H, S, lam_tmp, D)
+        call eigh(H, S, lam_tmp, D, 7)
     else
-        call eigh(H, S, lam, D)
+        nlam = count(focc(:,kappa) > tiny(1._dp))
+        call eigh(H, S, lam, D, nlam)
     end if
 
     do i = 1, size(focc,1)
         if (focc(i,kappa) < tiny(1._dp)) cycle
+        !print *, "lam(i): i =", i, nlam
 
         call c2fullc2(in, ib, D(:Nb,i), fullc)
         call fe2quad(xe, xin, xiq, in, fullc, uq)

--- a/src/fe.f90
+++ b/src/fe.f90
@@ -368,19 +368,6 @@ do e = 1, Ne
     end do
 end do
 
-!print *, "Checking symmetry"
-do j = 1, 2*Nb
-    do i = 1, j-1
-        if (abs(H(i,j) - H(j,i)) > 1e-8_dp) then
-            if (abs(H(i,j)-H(j,i)) / max(abs(H(i,j)), abs(H(j,i))) &
-                    > 1e-8_dp) then
-                print *, i, j, H(i,j)-H(j,i), H(i,j), H(j,i)
-                error stop "H not symmetric"
-            end if
-        end if
-        if (abs(S(i,j)-S(j,i)) > 1e-12_dp) error stop "S not symmetric"
-   end do
-end do
 end subroutine
 
 

--- a/src/lapack.f90
+++ b/src/lapack.f90
@@ -77,6 +77,18 @@ interface
     REAL(dp)           A( LDA, * ), B( LDB, * ), W( * ), WORK( * )
     END SUBROUTINE
 
+    SUBROUTINE DSYGVX( ITYPE, JOBZ, RANGE, UPLO, N, A, LDA, B, LDB, &
+                       VL, VU, IL, IU, ABSTOL, M, W, Z, LDZ, WORK, &
+                       LWORK, IWORK, IFAIL, INFO )
+    import :: dp
+    CHARACTER          JOBZ, RANGE, UPLO
+    INTEGER            IL, INFO, ITYPE, IU, LDA, LDB, LDZ, LWORK, M, N
+    REAL(dp)           ABSTOL, VL, VU
+    INTEGER            IFAIL( * ), IWORK( * )
+    REAL(dp)           A( LDA, * ), B( LDB, * ), W( * ), WORK( * ), &
+                       Z( LDZ, * )
+    END SUBROUTINE
+
     REAL(dp) FUNCTION DLAMCH( CMACH )
     import :: dp
     CHARACTER          CMACH

--- a/src/linalg.f90
+++ b/src/linalg.f90
@@ -13,7 +13,7 @@ module linalg
 
 contains
 
-  subroutine deigh_generalized(Am, Bm, lam, c)
+  subroutine deigh_generalized(Am, Bm, lam, c, nlam)
     ! solves generalized eigen value problem for all eigenvalues and eigenvectors
     ! Am must by symmetric, Bm symmetric positive definite.
     ! Only the lower triangular part of Am and Bm is used.
@@ -21,6 +21,7 @@ contains
     real(dp), intent(in) :: Bm(:,:)   ! RHS matrix: Am c = lam Bm c
     real(dp), intent(out) :: lam(:)   ! eigenvalues: Am c = lam Bm c
     real(dp), intent(out) :: c(:,:)   ! eigenvectors: Am c = lam Bm c; c(i,j) = ith component of jth vec.
+    integer, intent(in) :: nlam
     integer :: n
     ! lapack variables
     integer :: lwork, liwork, info
@@ -40,12 +41,12 @@ contains
     allocate(ifail(n))
     !call dsygvd(1,'V','L',n,c,n,Bmt,n,lam,work,lwork,iwork,liwork,info)
     il = 1
-    iu = 7
+    iu = nlam
     M = iu-il+1
     allocate(z(n,M))
     abstol = 1e-4_dp
     call dsygvx(1,'V','I','L',n,Am,n,Bm,n, &
-        0._dp, 0._dp, 1, 7, abstol, M, lam, c, n, work, &
+        0._dp, 0._dp, il, iu, abstol, M, lam, c, n, work, &
         lwork, iwork, ifail, info)
     !SUBROUTINE DSYGVD( ITYPE, JOBZ, UPLO, N, A, LDA, B, LDB, W, WORK, &
     !                   LWORK, IWORK, LIWORK, INFO )

--- a/src/linalg.f90
+++ b/src/linalg.f90
@@ -25,7 +25,7 @@ contains
     ! lapack variables
     integer :: lwork, liwork, info
     integer, allocatable :: iwork(:), ifail(:)
-    real(dp), allocatable :: Bmt(:,:), work(:), Z(:,:)
+    real(dp), allocatable :: Bmt(:,:), work(:), Z(:,:), Amt(:,:)
     integer :: il, iu, M
     real(dp) :: abstol
 
@@ -37,19 +37,18 @@ contains
     lwork = 1 + 6*n + 2*n**2
     liwork = 3 + 5*n
     allocate(Bmt(n,n), work(lwork), iwork(liwork))
+    allocate(Amt(n,n))
     allocate(ifail(n))
-    c = Am; Bmt = Bm  ! Bmt temporaries overwritten by dsygvd
+    Amt = Am; Bmt = Bm  ! Bmt temporaries overwritten by dsygvd
     !call dsygvd(1,'V','L',n,c,n,Bmt,n,lam,work,lwork,iwork,liwork,info)
     il = 1
     iu = 7
     M = iu-il+1
     allocate(z(n,M))
-    abstol = 1e-8_dp
-    call dsygvx(1,'V','I','L',n,c,n,Bmt,n, &
-        0._dp, 0._dp, 1, 7, abstol, M, lam, z, n, work, &
+    abstol = 1e-4_dp
+    call dsygvx(1,'V','I','L',n,Amt,n,Bmt,n, &
+        0._dp, 0._dp, 1, 7, abstol, M, lam, c, n, work, &
         lwork, iwork, ifail, info)
-    c = 0
-    c(:,:M) = z
     !SUBROUTINE DSYGVD( ITYPE, JOBZ, UPLO, N, A, LDA, B, LDB, W, WORK, &
     !                   LWORK, IWORK, LIWORK, INFO )
     !SUBROUTINE DSYGVX( ITYPE, JOBZ, RANGE, UPLO, N, A, LDA, B, LDB, &

--- a/src/linalg.f90
+++ b/src/linalg.f90
@@ -36,17 +36,15 @@ contains
     call assert_shape(c, [n, n], "eigh", "c")
     lwork = 1 + 6*n + 2*n**2
     liwork = 3 + 5*n
-    allocate(Bmt(n,n), work(lwork), iwork(liwork))
-    allocate(Amt(n,n))
+    allocate(work(lwork), iwork(liwork))
     allocate(ifail(n))
-    Amt = Am; Bmt = Bm  ! Bmt temporaries overwritten by dsygvd
     !call dsygvd(1,'V','L',n,c,n,Bmt,n,lam,work,lwork,iwork,liwork,info)
     il = 1
     iu = 7
     M = iu-il+1
     allocate(z(n,M))
     abstol = 1e-4_dp
-    call dsygvx(1,'V','I','L',n,Amt,n,Bmt,n, &
+    call dsygvx(1,'V','I','L',n,Am,n,Bm,n, &
         0._dp, 0._dp, 1, 7, abstol, M, lam, c, n, work, &
         lwork, iwork, ifail, info)
     !SUBROUTINE DSYGVD( ITYPE, JOBZ, UPLO, N, A, LDA, B, LDB, W, WORK, &

--- a/test/test_dft_dirac_fast.f90
+++ b/test/test_dft_dirac_fast.f90
@@ -59,7 +59,7 @@ xe(1) = rmin
 xe(2:) = meshexp(r0, rmax, a, Ne-1)
 call get_parent_quad_pts_wts(1, Nq, xiq, wtq)
 
-call solve_dirac(Z, p, xiq, wtq, xe, 1e-6_dp, energies, Etot, V, DOFs)
+call solve_dirac(Z, p, xiq, wtq, xe, 1e-5_dp, energies, Etot, V, DOFs)
 
 if ( .not. (size(energies) == size(energies_ref))) then
    error stop 'assert failed'


### PR DESCRIPTION
TODO:

* [ ] Refactor these changes so that regular use is unaffected
  * [ ] Put the new eigensolver into a new subroutine
  * [ ] Expose `accurate_eigensolver = .false.` to the top driver
  * [ ] Either keep symmetry check commented out, or expose via a parameter

Run with:
```console
$ fpm test --profile=release --flag "-ffast-math -march=native -framework Accelerate " test_dft_dirac_fast --verbose
$ time build/gfortran_BDCD69B59C14BD7C/test/test_dft_dirac_fast
 SCF iteration:           1
 SCF iteration:           2
 SCF iteration:           3
 SCF iteration:           4
 SCF iteration:           5
 SCF iteration:           6
 SCF iteration:           7
 SCF convergence error:   2.4220418857676123     
 SCF iteration:           8
 SCF convergence error:   5.9357534701121040E-003
 SCF iteration:           9
 SCF convergence error:   1.8806871048582252E-003
 SCF iteration:          10
 SCF convergence error:   1.0455984192958567E-004
 SCF iteration:          11
 SCF convergence error:   3.2101015676744282E-005
 SCF iteration:          12
 SCF convergence error:   1.1781998182414100E-005
 SCF iteration:          13
 SCF convergence error:   1.2883829185739160E-006
 SCF iteration:          14
 SCF convergence error:   8.7908847490325570E-007
 Comparison of calculated and reference energies

 Total energy:
               E           E_ref     error
 -28001.13232613 -28001.13232549  6.45E-07

 Eigenvalues:
   n               E           E_ref     error
   1  -4223.41902078  -4223.41902046  3.21E-07
   2   -789.48978230   -789.48978233  3.07E-08
   3   -761.37447596   -761.37447597  1.65E-08
   4   -622.84809453   -622.84809456  3.38E-08
   5   -199.42980561   -199.42980564  3.01E-08
   6   -186.66371306   -186.66371312  6.59E-08
   7   -154.70102661   -154.70102667  6.81E-08
   8   -134.54118022   -134.54118029  6.72E-08
   9   -128.01665731   -128.01665738  7.02E-08
  10    -50.78894802    -50.78894806  4.95E-08
  11    -45.03717123    -45.03717129  5.97E-08
  12    -36.68861043    -36.68861049  5.96E-08
  13    -27.52930618    -27.52930624  5.95E-08
  14    -25.98542885    -25.98542891  5.75E-08
  15    -13.88951417    -13.88951423  6.03E-08
  16    -13.48546963    -13.48546969  6.33E-08
  17    -11.29558706    -11.29558710  4.17E-08
  18     -9.05796421     -9.05796425  4.43E-08
  19     -7.06929559     -7.06929563  4.12E-08
  20     -3.79741619     -3.79741623  3.41E-08
  21     -3.50121715     -3.50121718  3.41E-08
  22     -0.14678836     -0.14678838  2.99E-08
  23     -0.11604714     -0.11604717  2.92E-08
  24     -1.74803993     -1.74803995  2.87E-08
  25     -1.10111897     -1.10111900  3.12E-08
  26     -0.77578414     -0.77578418  3.45E-08
  27     -0.10304078     -0.10304082  3.04E-08
  28     -0.08480199     -0.08480202  3.05E-08
  29     -0.16094726     -0.16094728  2.65E-08
build/gfortran_BDCD69B59C14BD7C/test/test_dft_dirac_fast  0.40s user 0.01s system 99% cpu 0.404 total
```