### PR TITLE
fix: allocate lam_tmp before passing to solve_dirac_eigenproblem

### DIFF
--- a/src/schroed_dirac_solver.f90
+++ b/src/schroed_dirac_solver.f90
@@ -64,6 +64,7 @@ contains
 
     allocate(H(DOFS, DOFS), S(DOFS), DSQ(DOFS), uq(Nq,Ne))
     allocate(D(DOFS, DOFS), lam2(DOFS), rho(Nq,Ne), fullc(Nn))
+    allocate(lam_tmp(DOFS))
     if (dirac_int == 1) then
         allocate(lam(47))
         allocate(eigfn(Nq, Ne, 49))


### PR DESCRIPTION
The crash was caused by passing an unallocated array (lam_tmp) to solve_dirac_eigenproblem in src/schroed_dirac_solver.f90 (around line 155).

LFortran correctly detects this and raises a runtime error: “argument is unallocated”.

This fix ensures lam_tmp is properly allocated before the call, preventing the runtime failure. The issue is in featom code and is not a bug in LFortran.